### PR TITLE
Basic integration with Eventbrite

### DIFF
--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.admin.inc
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.admin.inc
@@ -11,6 +11,13 @@ function eventbrite_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get('eventbrite_oauth_token', ''),
     '#required' => TRUE,
   );
+  $form['role'] = array(
+    '#type' => 'select',
+    '#title' => t('User role for new users'),
+    '#options' => user_roles(TRUE),
+    '#default_value' => variable_get('eventbrite_role', ''),
+    '#description' => t('This role will be automatically assigned to all imported users.'),
+  );
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -23,6 +30,9 @@ function eventbrite_admin_config_form($form, &$form_state) {
  */
 function eventbrite_admin_config_form_submit(&$form, &$form_state) {
   variable_set('eventbrite_oauth_token', $form_state['values']['oauth_token']);
-  drupal_set_message(t('Token has been saved.'));
+  variable_set('eventbrite_role', $form_state['values']['role']);
+  $roles = user_roles(TRUE);
+  variable_set('eventbrite_role_name', $roles[$form_state['values']['role']]);
+  drupal_set_message(t('Settings has been saved.'));
   drupal_goto('/');
 }

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.admin.inc
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.admin.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * {@inheritdoc}
+ */
+function eventbrite_admin_config_form($form, &$form_state) {
+  $form = array();
+  $form['oauth_token'] = array(
+    '#type' => 'textfield',
+    '#title' => t('oAuth token'),
+    '#default_value' => variable_get('eventbrite_oauth_token', ''),
+    '#required' => TRUE,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+  return $form;
+}
+
+/**
+ * {@inheritdoc}
+ */
+function eventbrite_admin_config_form_submit(&$form, &$form_state) {
+  variable_set('eventbrite_oauth_token', $form_state['values']['oauth_token']);
+  drupal_set_message(t('Token has been saved.'));
+  drupal_goto('/');
+}

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.info
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.info
@@ -1,0 +1,4 @@
+name = Eventbrite integration
+description = A module that provides webhook integration with Eventbrite API.
+package = Integrations
+core = 7.x

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -30,11 +30,10 @@ function eventbrite_webhook_process() {
     }
     $request_url = $webhook['api_url'] . '?expand=attendees&token=' . $token;
     $order = json_decode(file_get_contents($request_url), TRUE);
-    watchdog('eventbrite', print_r($order, TRUE));
     $attendees = $order['attendees'];
     foreach ($attendees as $attendee) {
       $email = $attendee['profile']['email'];
-      if (user_load_by_mail($email) !== FALSE) {
+      if (user_load_by_mail($email) === FALSE) {
         $account = drupal_anonymous_user();
         $account->mail = $email;
         $account->name = $email;
@@ -44,7 +43,7 @@ function eventbrite_webhook_process() {
         watchdog('eventbrite', 'User #@id has been created', array('@id' => $account->uid), WATCHDOG_INFO);
       }
       else {
-        watchdog('eventbrite', 'User with email @email has been created', array('@email' => $email), WATCHDOG_INFO);
+        watchdog('eventbrite', "User with email @email hasn't been created", array('@email' => $email), WATCHDOG_INFO);
       }
     }
   }

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -37,7 +37,12 @@ function eventbrite_webhook_process() {
         $account = drupal_anonymous_user();
         $account->mail = $email;
         $account->name = $email;
+        $account->status = 1;
         $account = user_save($account);
+        // Modify user role, if any is selected
+        if(!empty($rid = variable_get('eventbrite_role', ''))) {
+          user_multiple_role_edit(array($account->uid),'add_role',$rid);
+        }
         // Notify user about new account.
         _user_mail_notify('register_admin_created', $account);
         watchdog('eventbrite', 'User #@id has been created', array('@id' => $account->uid), WATCHDOG_INFO);

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -20,6 +20,31 @@ function eventbrite_menu() {
 }
 
 function eventbrite_webhook_process() {
-  $request_body = file_get_contents('php://input');
-  watchdog('eventbrite', $request_body);
+  $webhook = json_decode(file_get_contents('php://input'), TRUE);
+  watchdog('eventbrite', print_r($webhook, TRUE));
+  if ($webhook['config']['action'] === 'order.placed') {
+    $token = variable_get('eventbrite_oauth_token', '');
+    if (empty($token)) {
+      watchdog('eventbrite', 'You have to fill your token first.', array(), WATCHDOG_ERROR);
+      return;
+    }
+    $request_url = $webhook['api_url'] . '?extend=attendees&token=' . $token;
+    $order = json_decode(file_get_contents($request_url), TRUE);
+    $attendees = $order['attendees'];
+    foreach ($attendees as $attendee) {
+      $email = $attendee['profile']['email'];
+      if (user_load_by_mail($email) !== FALSE) {
+        $account = drupal_anonymous_user();
+        $account->mail = $email;
+        $account->name = $email;
+        $account = user_save($account);
+        // Notify user about new account.
+        _user_mail_notify('register_admin_created', $account);
+        watchdog('eventbrite', 'User #@id has been created', array('@id' => $account->uid), WATCHDOG_INFO);
+      }
+      else {
+        watchdog('eventbrite', 'User with email @email has been created', array('@email' => $email), WATCHDOG_INFO);
+      }
+    }
+  }
 }

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Implements hook_menu().
+ */
+function eventbrite_menu() {
+  return array(
+    'admin/config/system/eventbrite' => array(
+      'title' => 'Eventbrite',
+      'description' => 'Setup Eventbrite integration',
+      'page callback' => 'eventbrite_admin_config_form',
+      'access arguments' => array('administer site configuration'),
+      'file' => 'eventbrite.admin.inc',
+    ),
+    'api/v3/eventbrite/endpoint' => array(
+      'page callback' => 'eventbrite_webhook_process',
+      'access arguments' => array('access content'),
+    ),
+  );
+}
+
+function eventbrite_webhook_process() {
+  watchdog('eventbrite', print_r($_POST, TRUE));
+}

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -8,7 +8,8 @@ function eventbrite_menu() {
     'admin/config/system/eventbrite' => array(
       'title' => 'Eventbrite',
       'description' => 'Setup Eventbrite integration',
-      'page callback' => 'eventbrite_admin_config_form',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('eventbrite_admin_config_form'),
       'access arguments' => array('administer site configuration'),
       'file' => 'eventbrite.admin.inc',
     ),

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -20,5 +20,6 @@ function eventbrite_menu() {
 }
 
 function eventbrite_webhook_process() {
-  watchdog('eventbrite', print_r($_POST, TRUE));
+  $request_body = file_get_contents('php://input');
+  watchdog('eventbrite', $request_body);
 }

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -28,7 +28,7 @@ function eventbrite_webhook_process() {
       watchdog('eventbrite', 'You have to fill your token first.', array(), WATCHDOG_ERROR);
       return;
     }
-    $request_url = $webhook['api_url'] . '?extend=attendees&token=' . $token;
+    $request_url = $webhook['api_url'] . '?expand=attendees&token=' . $token;
     $order = json_decode(file_get_contents($request_url), TRUE);
     watchdog('eventbrite', print_r($order, TRUE));
     $attendees = $order['attendees'];

--- a/profiles/campsite/modules/custom/eventbrite/eventbrite.module
+++ b/profiles/campsite/modules/custom/eventbrite/eventbrite.module
@@ -22,7 +22,6 @@ function eventbrite_menu() {
 
 function eventbrite_webhook_process() {
   $webhook = json_decode(file_get_contents('php://input'), TRUE);
-  watchdog('eventbrite', print_r($webhook, TRUE));
   if ($webhook['config']['action'] === 'order.placed') {
     $token = variable_get('eventbrite_oauth_token', '');
     if (empty($token)) {
@@ -31,6 +30,7 @@ function eventbrite_webhook_process() {
     }
     $request_url = $webhook['api_url'] . '?extend=attendees&token=' . $token;
     $order = json_decode(file_get_contents($request_url), TRUE);
+    watchdog('eventbrite', print_r($order, TRUE));
     $attendees = $order['attendees'];
     foreach ($attendees as $attendee) {
       $email = $attendee['profile']['email'];


### PR DESCRIPTION
We provide very basic integration with Eventbrite. After order is created, our website is notified about order and fetch information about attendees and create account for every one of them.
Steps to test:
1. log in to eventbrite account and create new Application (https://www.eventbrite.com/myaccount/apps/)
2. create testing event and set required information by every attendee
3. create webhook, which will be responding to order creation and will end in http://eventbrite-h3o5ngsst7fts.eu.platform.sh/api/v3/eventbrite/endpoint
4. login to eventbrite testing environment on platform.sh (http://eventbrite-h3o5ngsst7fts.eu.platform.sh/)
5. create testing order, new account(s) should be created.
